### PR TITLE
Include id of oxpoints entity for which the descendants are being returned

### DIFF
--- a/moxie/places/views.py
+++ b/moxie/places/views.py
@@ -155,7 +155,8 @@ class PoiOrgDescendants(ServiceView):
     def handle_request(self, ident):
         poi_service = POIService.from_context()
         descendants = poi_service.get_organisational_descendants(ident)
-        return {'id': ident, 'descendants': descendants}
+        descendants['id'] = ident
+        return descendants
 
     @accepts(HAL_JSON, JSON)
     def as_hal_json(self, descendants):

--- a/moxie/places/views.py
+++ b/moxie/places/views.py
@@ -154,7 +154,8 @@ class PoiOrgDescendants(ServiceView):
 
     def handle_request(self, ident):
         poi_service = POIService.from_context()
-        return poi_service.get_organisational_descendants(ident)
+        descendants = poi_service.get_organisational_descendants(ident)
+        return {'id': ident, 'descendants': descendants}
 
     @accepts(HAL_JSON, JSON)
     def as_hal_json(self, descendants):


### PR DESCRIPTION
This better facilitates caching of queries by consumers (e.g. talks.ox)